### PR TITLE
Channel management + pins + env tweaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Twitch API Credentials
+# Get these from: https://dev.twitch.tv/console/apps
+NUXT_TWITCH_APP_CLIENT_ID=your_twitch_client_id_here
+NUXT_TWITCH_APP_CLIENT_SECRET=your_twitch_client_secret_here

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "Mizu",
         "Nuxt",
         "nuxtjs",
+        "ondemand",
         "peepochat",
         "persistedstate",
         "pinia",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2025-12-27
+
 ### Added
 
 -   Channel management system with persistent storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Channel management system with persistent storage
+-   Add Channel modal for searching and adding Twitch channels via API
+-   Channel removal functionality in channel dropdown menu
+-   Channel pin/unpin functionality to keep favorite channels at the top
+-   Dynamic channel list rendering from store in sidebar with pinned channels sorted first
+-   Environment variables configuration for Twitch API credentials
+
+### Changed
+
+-   Channel navigation now forces full page reload for proper state reset
+-   Twitch API credentials moved from hardcoded values to environment variables (NUXT_TWITCH_APP_CLIENT_ID, NUXT_TWITCH_APP_CLIENT_SECRET)
+
 ## [0.0.1] - 2024-04-08
 
 ### Added

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,8 +26,8 @@ export default defineNuxtConfig({
 	},
 
 	runtimeConfig: {
-		twitchAppClientId: '',
-		twitchAppClientSecret: '',
+		twitchAppClientId: process.env.NUXT_TWITCH_APP_CLIENT_ID || '',
+		twitchAppClientSecret: process.env.NUXT_TWITCH_APP_CLIENT_SECRET || '',
 		public: {
 			version,
 			userAgent: `${name}/${version} (${author.email})`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3820,6 +3820,7 @@
 		},
 		"node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
 			"version": "1.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "peepochat",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"author": {
 		"name": "DanMizu",
 		"email": "dan@danmizu.dev",

--- a/src/app.vue
+++ b/src/app.vue
@@ -2,7 +2,7 @@
 // add events when the component mounts.
 onMounted(async () => {
 	// run client-side only
-	if (process.browser) {
+	if (process.client) {
 		window.addEventListener('contextmenu', preventContextMenu);
 	}
 });
@@ -10,7 +10,7 @@ onMounted(async () => {
 // remove events when un-mounting the component.
 onUnmounted(() => {
 	// run client-side only
-	if (process.browser) {
+	if (process.client) {
 		window.removeEventListener('contextmenu', preventContextMenu);
 	}
 });

--- a/src/components/buttons/Button.vue
+++ b/src/components/buttons/Button.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { ButtonVariant, ButtonSize } from '#ui/types/button';
+
 const props = withDefaults(
 	defineProps<{
 		to?: string;
@@ -7,8 +9,8 @@ const props = withDefaults(
 		text?: string;
 		class?: string;
 		ui?: any;
-		variant?: string;
-		size?: string;
+		variant?: ButtonVariant;
+		size?: ButtonSize;
 	}>(),
 	{
 		variant: 'ghost',

--- a/src/components/buttons/ChannelButton.vue
+++ b/src/components/buttons/ChannelButton.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+// get state
+import useStore from '~/store';
+const store = useStore();
+
 // localization
 const localize = useI18n().t;
 
@@ -13,6 +17,25 @@ const props = defineProps<{
 		};
 	};
 }>();
+
+// methods
+const handleRemove = () => {
+	const index = store.channels.findIndex(
+		(c) => c.name.toLowerCase() === props.channel.name.toLowerCase()
+	);
+	if (index !== -1) {
+		store.channels.splice(index, 1);
+	}
+};
+
+const handleChannelClick = () => {
+	const route = useRoute();
+	const newPath = '/channel/twitch/' + props.channel.platform.twitch;
+	// Force full page reload if navigating to different channel
+	if (route.path !== newPath) {
+		window.location.href = newPath;
+	}
+};
 
 // dropdown contents
 const dropdownContentAnon = [
@@ -35,6 +58,7 @@ const dropdownContentAnon = [
 		{
 			label: localize('sidebar.channel.dropdown.remove'),
 			icon: 'i-ic-baseline-remove-circle',
+			click: handleRemove,
 		},
 	],
 ];
@@ -66,7 +90,7 @@ const dropdownOpen = ref(false);
 		<Button
 			:label="props.channel.name"
 			variant="hidden"
-			:to="'/channel/twitch/' + props.channel.platform.twitch"
+			@click="handleChannelClick"
 			@click.right="
 				() => {
 					dropdownOpen = true;

--- a/src/components/buttons/ChannelButton.vue
+++ b/src/components/buttons/ChannelButton.vue
@@ -8,14 +8,7 @@ const localize = useI18n().t;
 
 // properties
 const props = defineProps<{
-	channel: {
-		name: string;
-		avatarURL: string;
-		live: boolean;
-		platform: {
-			twitch?: string;
-		};
-	};
+	channel: IChannel;
 }>();
 
 // methods
@@ -28,6 +21,15 @@ const handleRemove = () => {
 	}
 };
 
+const handlePin = () => {
+	const channel = store.channels.find(
+		(c) => c.name.toLowerCase() === props.channel.name.toLowerCase()
+	);
+	if (channel) {
+		channel.pinned = !channel.pinned;
+	}
+};
+
 const handleChannelClick = () => {
 	const route = useRoute();
 	const newPath = '/channel/twitch/' + props.channel.platform.twitch;
@@ -37,8 +39,15 @@ const handleChannelClick = () => {
 	}
 };
 
+// computed for pin label
+const pinLabel = computed(() => {
+	return props.channel.pinned
+		? localize('sidebar.channel.dropdown.unpin')
+		: localize('sidebar.channel.dropdown.pin');
+});
+
 // dropdown contents
-const dropdownContentAnon = [
+const dropdownContentAnon = computed(() => [
 	[
 		{
 			label: localize('sidebar.channel.dropdown.visit_stream'),
@@ -50,8 +59,9 @@ const dropdownContentAnon = [
 	],
 	[
 		{
-			label: localize('sidebar.channel.dropdown.pin'),
+			label: pinLabel.value,
 			icon: 'i-ic-round-push-pin',
+			click: handlePin,
 		},
 	],
 	[
@@ -61,7 +71,7 @@ const dropdownContentAnon = [
 			click: handleRemove,
 		},
 	],
-];
+]);
 
 // state
 const dropdownOpen = ref(false);

--- a/src/components/modals/AddChannelModal.vue
+++ b/src/components/modals/AddChannelModal.vue
@@ -30,9 +30,12 @@ const findChannel = async () => {
 		});
 
 		if (!response.data) {
-			error.value = localize('view.channel.no_channel_found.description', {
-				name: channelName.value,
-			});
+			error.value = localize(
+				'view.channel.no_channel_found.description',
+				{
+					name: channelName.value,
+				}
+			);
 			return;
 		}
 
@@ -40,7 +43,7 @@ const findChannel = async () => {
 		emit('channel-added', {
 			name: response.data.name,
 			avatarURL: response.data.profilePictureUrl,
-			live: false, // pode buscar stream depois
+			live: false, // search for stream later
 			pinned: false,
 			platform: {
 				twitch: response.data.name,
@@ -51,7 +54,7 @@ const findChannel = async () => {
 		channelName.value = '';
 		emit('update:open', false);
 	} catch (err) {
-		error.value = 'Erro ao buscar canal';
+		error.value = 'Error fetching channel';
 	} finally {
 		isLoading.value = false;
 	}
@@ -88,7 +91,9 @@ const close = () => {
 			<div class="flex flex-col gap-4">
 				<UInput
 					v-model="channelName"
-					:placeholder="localize('modal.add_channel.input.placeholder')"
+					:placeholder="
+						localize('modal.add_channel.input.placeholder')
+					"
 					@keyup.enter="findChannel"
 					:disabled="isLoading"
 				/>
@@ -100,8 +105,12 @@ const close = () => {
 
 			<template #footer>
 				<div class="flex justify-end gap-2">
-					<UButton variant="ghost" @click="close" :disabled="isLoading">
-						Cancelar
+					<UButton
+						variant="ghost"
+						@click="close"
+						:disabled="isLoading"
+					>
+						Cancel
 					</UButton>
 					<UButton
 						@click="findChannel"
@@ -115,4 +124,3 @@ const close = () => {
 		</UCard>
 	</UModal>
 </template>
-

--- a/src/components/modals/AddChannelModal.vue
+++ b/src/components/modals/AddChannelModal.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+// localization
+const localize = useI18n().t;
+
+// props
+const props = defineProps<{
+	open: boolean;
+}>();
+
+const emit = defineEmits<{
+	'update:open': [value: boolean];
+	'channel-added': [channel: IChannel];
+}>();
+
+// state
+const channelName = ref('');
+const isLoading = ref(false);
+const error = ref<string | null>(null);
+
+// methods
+const findChannel = async () => {
+	if (!channelName.value.trim()) return;
+
+	isLoading.value = true;
+	error.value = null;
+
+	try {
+		const response = await $fetch('/api/v1/twitch/user', {
+			params: { name: channelName.value.trim() },
+		});
+
+		if (!response.data) {
+			error.value = localize('view.channel.no_channel_found.description', {
+				name: channelName.value,
+			});
+			return;
+		}
+
+		// Emit channel data
+		emit('channel-added', {
+			name: response.data.name,
+			avatarURL: response.data.profilePictureUrl,
+			live: false, // pode buscar stream depois
+			platform: {
+				twitch: response.data.name,
+			},
+		});
+
+		// Reset and close
+		channelName.value = '';
+		emit('update:open', false);
+	} catch (err) {
+		error.value = 'Erro ao buscar canal';
+	} finally {
+		isLoading.value = false;
+	}
+};
+
+const close = () => {
+	channelName.value = '';
+	error.value = null;
+	emit('update:open', false);
+};
+</script>
+
+<template>
+	<UModal
+		:model-value="open"
+		@update:model-value="emit('update:open', $event)"
+		@close="close"
+		:ui="{
+			width: 'w-full max-w-md',
+			container: 'items-center',
+		}"
+	>
+		<UCard
+			:ui="{
+				width: 'w-full',
+			}"
+		>
+			<template #header>
+				<h3 class="text-lg font-semibold">
+					{{ localize('modal.add_channel.header') }}
+				</h3>
+			</template>
+
+			<div class="flex flex-col gap-4">
+				<UInput
+					v-model="channelName"
+					:placeholder="localize('modal.add_channel.input.placeholder')"
+					@keyup.enter="findChannel"
+					:disabled="isLoading"
+				/>
+
+				<div v-if="error" class="text-red-500 text-sm">
+					{{ error }}
+				</div>
+			</div>
+
+			<template #footer>
+				<div class="flex justify-end gap-2">
+					<UButton variant="ghost" @click="close" :disabled="isLoading">
+						Cancelar
+					</UButton>
+					<UButton
+						@click="findChannel"
+						:loading="isLoading"
+						:disabled="!channelName.trim()"
+					>
+						{{ localize('modal.add_channel.button.find') }}
+					</UButton>
+				</div>
+			</template>
+		</UCard>
+	</UModal>
+</template>
+

--- a/src/components/modals/AddChannelModal.vue
+++ b/src/components/modals/AddChannelModal.vue
@@ -41,6 +41,7 @@ const findChannel = async () => {
 			name: response.data.name,
 			avatarURL: response.data.profilePictureUrl,
 			live: false, // pode buscar stream depois
+			pinned: false,
 			platform: {
 				twitch: response.data.name,
 			},

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -57,6 +57,26 @@ const handleChannelAdded = (channel: IChannel) => {
 		store.channels.push(channel);
 	}
 };
+
+// migrar canais antigos que não têm propriedade pinned
+onMounted(() => {
+	store.channels.forEach((channel) => {
+		if (typeof channel.pinned === 'undefined') {
+			channel.pinned = false;
+		}
+	});
+});
+
+// ordenar canais: pinned primeiro, depois os demais
+const sortedChannels = computed(() => {
+	return [...store.channels].sort((a, b) => {
+		// Pinned channels first
+		if (a.pinned && !b.pinned) return -1;
+		if (!a.pinned && b.pinned) return 1;
+		// Keep original order for same pinned status
+		return 0;
+	});
+});
 </script>
 
 <template>
@@ -69,7 +89,7 @@ const handleChannelAdded = (channel: IChannel) => {
 				<ul>
 					<!-- Channel Buttons -->
 					<li
-						v-for="channel in store.channels"
+						v-for="channel in sortedChannels"
 						:key="channel.name"
 						class="flex justify-center mb-3"
 					>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -42,23 +42,23 @@ const sidebarToggleButtonStyle = computed(() => {
 	};
 });
 
-// state do modal
+// modal state
 const isAddChannelModalOpen = ref(false);
 
-// método para adicionar canal
+// add channel
 const handleChannelAdded = (channel: IChannel) => {
-	// Verificar se o canal já existe
+	// check if the channel already exists
 	const channelExists = store.channels.some(
 		(c) => c.name.toLowerCase() === channel.name.toLowerCase()
 	);
 
 	if (!channelExists) {
-		// Adicionar ao store
+		// add to store
 		store.channels.push(channel);
 	}
 };
 
-// migrar canais antigos que não têm propriedade pinned
+// migrate old channels that do not have pinned ownership
 onMounted(() => {
 	store.channels.forEach((channel) => {
 		if (typeof channel.pinned === 'undefined') {
@@ -67,12 +67,13 @@ onMounted(() => {
 	});
 });
 
-// ordenar canais: pinned primeiro, depois os demais
+// order channels: pinned first, then the others
 const sortedChannels = computed(() => {
 	return [...store.channels].sort((a, b) => {
 		// Pinned channels first
 		if (a.pinned && !b.pinned) return -1;
 		if (!a.pinned && b.pinned) return 1;
+
 		// Keep original order for same pinned status
 		return 0;
 	});

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -57,7 +57,7 @@ const sidebarToggleButtonStyle = computed(() => {
 							:channel="{
 								name: 'felps',
 								avatarURL:
-									'https://yt3.googleusercontent.com/zPTE40jgUqbC-8e8BwuivrUMZMcQPiMKSkVoerB0GifBqY6RBJ5rK7rjOY-wsHYNLRzj3wd67gI=s900-c-k-c0x00ffffff-no-rj',
+									'https://static-cdn.jtvnw.net/jtv_user_pictures/2626d071-0773-47f3-867e-a027412bdb2a-profile_image-70x70.png',
 								live: false,
 								platform: {
 									twitch: 'felps',

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -41,6 +41,22 @@ const sidebarToggleButtonStyle = computed(() => {
 		},
 	};
 });
+
+// state do modal
+const isAddChannelModalOpen = ref(false);
+
+// método para adicionar canal
+const handleChannelAdded = (channel: IChannel) => {
+	// Verificar se o canal já existe
+	const channelExists = store.channels.some(
+		(c) => c.name.toLowerCase() === channel.name.toLowerCase()
+	);
+
+	if (!channelExists) {
+		// Adicionar ao store
+		store.channels.push(channel);
+	}
+};
 </script>
 
 <template>
@@ -52,18 +68,12 @@ const sidebarToggleButtonStyle = computed(() => {
 			<template #channels>
 				<ul>
 					<!-- Channel Buttons -->
-					<li class="flex justify-center mb-3">
-						<ChannelButton
-							:channel="{
-								name: 'felps',
-								avatarURL:
-									'https://static-cdn.jtvnw.net/jtv_user_pictures/2626d071-0773-47f3-867e-a027412bdb2a-profile_image-70x70.png',
-								live: false,
-								platform: {
-									twitch: 'felps',
-								},
-							}"
-						/>
+					<li
+						v-for="channel in store.channels"
+						:key="channel.name"
+						class="flex justify-center mb-3"
+					>
+						<ChannelButton :channel="channel" />
 					</li>
 
 					<!-- Add Channel Button -->
@@ -84,7 +94,7 @@ const sidebarToggleButtonStyle = computed(() => {
 								},
 							}"
 							size="lg"
-							to="/"
+							@click="isAddChannelModalOpen = true"
 						/>
 					</li>
 				</ul>
@@ -135,5 +145,11 @@ const sidebarToggleButtonStyle = computed(() => {
 		<div class="static h-full w-fit grow scrollbar-hidden">
 			<slot />
 		</div>
+
+		<!-- Add Channel Modal -->
+		<AddChannelModal
+			v-model:open="isAddChannelModalOpen"
+			@channel-added="handleChannelAdded"
+		/>
 	</div>
 </template>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -55,12 +55,12 @@ const sidebarToggleButtonStyle = computed(() => {
 					<li class="flex justify-center mb-3">
 						<ChannelButton
 							:channel="{
-								name: 'pokelawls',
+								name: 'felps',
 								avatarURL:
-									'https://cdn.7tv.app/pp/611ea25d3990c04e921506f7/743b9aca64cc46b49b16bb2c0a1c5f44',
+									'https://yt3.googleusercontent.com/zPTE40jgUqbC-8e8BwuivrUMZMcQPiMKSkVoerB0GifBqY6RBJ5rK7rjOY-wsHYNLRzj3wd67gI=s900-c-k-c0x00ffffff-no-rj',
 								live: false,
 								platform: {
-									twitch: 'pokelawls',
+									twitch: 'felps',
 								},
 							}"
 						/>

--- a/src/store/defaults.ts
+++ b/src/store/defaults.ts
@@ -3,4 +3,7 @@ export default {
 	defaultSettings: {
 		isSidebarExpanded: true,
 	} as ISettings,
+
+	// default channels
+	defaultChannels: [] as IChannel[],
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,6 +22,7 @@ export default defineStore(
 		const version: Ref<string> = ref(useRuntimeConfig().public.version);
 		const settings: Ref<ISettings> = ref(defaults.defaultSettings);
 		const globalBadges: Ref<IChatBadgeList> = ref({});
+		const channels: Ref<IChannel[]> = ref(defaults.defaultChannels);
 
 		// get global badge data (async)
 		useFetch('/api/v1/twitch/badges').then((response) => {
@@ -35,6 +36,7 @@ export default defineStore(
 			version,
 			settings,
 			globalBadges,
+			channels,
 		};
 	},
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -57,4 +57,14 @@ declare global {
 		userName: string;
 		viewers: number;
 	}
+
+	// Channel
+	interface IChannel {
+		name: string;
+		avatarURL: string;
+		live: boolean;
+		platform: {
+			twitch?: string;
+		};
+	}
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -63,6 +63,7 @@ declare global {
 		name: string;
 		avatarURL: string;
 		live: boolean;
+		pinned: boolean;
 		platform: {
 			twitch?: string;
 		};


### PR DESCRIPTION
This PR adds a basic channel management system and some improvements around it.

You can now add channels through a modal and pin them on the left sidebar.
Also cleaned up config a bit by moving stuff to `.env`.

Nothing too fancy, just making the app more flexible and nicer to use.

---

## **What’s inside**

* Channel management with add modal
* Pin/unpin channels on the sidebar
* Channel state persistence
* `.env` support + `.env.example`
* Small UI and config tweaks
* CHANGELOG update

---

## **How to test**

* Run the app
* Add a channel
* Pin it
* Change channels
* Remove a channel

---

## **TODO**
* I’m currently testing code to fetch the Kick chat, so expect a few upcoming pull requests with Kick chat support as well.

#### *By the way, you can ignore the Felps commits, they were just for testing promises, and all of those changes were removed after I got the channel buttons working properly. It is a streamer from my country :)*